### PR TITLE
Switch to https urls for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "singleapplication"]
 	path = singleapplication
-	url = git@github.com:itay-grudev/SingleApplication.git
+	url = https://github.com/itay-grudev/SingleApplication.git


### PR DESCRIPTION
This allows for submodules to be fetched anonymously over https, which is a requirement for automated installers such as [Nix](https://nixos.org/). With this fix in place, I've successfully packaged this lovely little app for NixOS, and I'll contribute the package to NixPkgs shortly!